### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/javadoc/1.12.2/net/minecraftforge/common/util/Constants.AttributeModifierOperation.html
+++ b/javadoc/1.12.2/net/minecraftforge/common/util/Constants.AttributeModifierOperation.html
@@ -116,7 +116,7 @@ extends java.lang.Object</pre>
  Order of operations are <a href="../../../../net/minecraftforge/common/util/Constants.AttributeModifierOperation.html#ADD"><code>ADD</code></a>, <a href="../../../../net/minecraftforge/common/util/Constants.AttributeModifierOperation.html#ADD_MULTIPLE"><code>ADD_MULTIPLE</code></a>, <a href="../../../../net/minecraftforge/common/util/Constants.AttributeModifierOperation.html#MULTIPLY"><code>MULTIPLY</code></a></div>
 <dl>
 <dt><span class="seeLabel">See Also:</span></dt>
-<dd><a href="https://minecraft.gamepedia.com/Attribute#Operations">Minecraft Wiki</a></dd>
+<dd><a href="https://minecraft.wiki/w/Attribute#Operations">Minecraft Wiki</a></dd>
 </dl>
 </li>
 </ul>

--- a/javadoc/1.12.2/net/minecraftforge/server/terminalconsole/MinecraftFormattingConverter.html
+++ b/javadoc/1.12.2/net/minecraftforge/server/terminalconsole/MinecraftFormattingConverter.html
@@ -147,7 +147,7 @@ extends org.apache.logging.log4j.core.pattern.LogEventPatternConverter</pre>
  <code>%minecraftFormatting{%message}{strip}</code></p></div>
 <dl>
 <dt><span class="seeLabel">See Also:</span></dt>
-<dd><a href="http://minecraft.gamepedia.com/Formatting_codes">
+<dd><a href="http://minecraft.wiki/w/Formatting_codes">
      Formatting Codes</a></dd>
 </dl>
 </li>

--- a/javadoc/1.13.2/net/minecraftforge/common/util/Constants.AttributeModifierOperation.html
+++ b/javadoc/1.13.2/net/minecraftforge/common/util/Constants.AttributeModifierOperation.html
@@ -114,7 +114,7 @@ extends java.lang.Object</pre>
  Order of operations are <a href="../../../../net/minecraftforge/common/util/Constants.AttributeModifierOperation.html#ADD"><code>ADD</code></a>, <a href="../../../../net/minecraftforge/common/util/Constants.AttributeModifierOperation.html#ADD_MULTIPLE"><code>ADD_MULTIPLE</code></a>, <a href="../../../../net/minecraftforge/common/util/Constants.AttributeModifierOperation.html#MULTIPLY"><code>MULTIPLY</code></a></div>
 <dl>
 <dt><span class="seeLabel">See Also:</span></dt>
-<dd><a href="https://minecraft.gamepedia.com/Attribute#Operations">Minecraft Wiki</a></dd>
+<dd><a href="https://minecraft.wiki/w/Attribute#Operations">Minecraft Wiki</a></dd>
 </dl>
 </li>
 </ul>


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.